### PR TITLE
Breaking changes: Introduce `@top`, move clock/reset configurations, other updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,17 +133,20 @@ lazy val dependencies =
     private val scalafmtV = "3.8.1"
     private val airframelogV = "24.5.2"
     private val oslibV = "0.9.2"
+    private val scoptV = "4.1.0"
     val scodec = "org.scodec" %% "scodec-bits" % scodecV
     val munit = "org.scalameta" %% "munit" % munitV % Test
     val scalafmt = ("org.scalameta" %% "scalafmt-dynamic" % scalafmtV).cross(CrossVersion.for3Use2_13)
     val airframelog = "org.wvlet.airframe" %% "airframe-log" % airframelogV
     val oslib = "com.lihaoyi" %% "os-lib" % oslibV
+    val scopt = "com.github.scopt" %% "scopt" % scoptV
   }
 
 lazy val commonDependencies = Seq(
   dependencies.scodec,
   dependencies.munit,
-  dependencies.airframelog
+  dependencies.airframelog,
+  dependencies.scopt
 )
 
 // SETTINGS

--- a/compiler/ir/src/main/scala/dfhdl/compiler/analysis/DFValAnalysis.scala
+++ b/compiler/ir/src/main/scala/dfhdl/compiler/analysis/DFValAnalysis.scala
@@ -235,7 +235,7 @@ extension (dfVal: DFVal)
             applyIdx match
               case DFVal.Alias.ApplyIdx.Const(i) =>
                 val maxValue = relVal.dfType match
-                  case vector: DFVector => vector.cellDims.head - 1
+                  case vector: DFVector => vector.length - 1
                   case bits: DFBits     => bits.width - 1
                   case _                => ???
                 s"_${i.toPaddedString(maxValue)}"

--- a/compiler/ir/src/main/scala/dfhdl/compiler/ir/Config.scala
+++ b/compiler/ir/src/main/scala/dfhdl/compiler/ir/Config.scala
@@ -62,5 +62,6 @@ end RstCfg
 
 type RTDomainCfg = ConfigD[RTDomainCfg.Explicit]
 object RTDomainCfg:
-  final case class Explicit(name: String, clkCfg: ClkCfg, rstCfg: RstCfg) extends NamedGlobal
-      derives CanEqual
+  final case class Explicit(name: String, clkCfg: ClkCfg, rstCfg: RstCfg)
+      extends NamedGlobal,
+        DFTagOf[DFDesignBlock] derives CanEqual

--- a/compiler/ir/src/main/scala/dfhdl/compiler/ir/DFType.scala
+++ b/compiler/ir/src/main/scala/dfhdl/compiler/ir/DFType.scala
@@ -215,11 +215,13 @@ object DFEnum extends DFType.Companion[DFEnum, Option[BigInt]]
 /////////////////////////////////////////////////////////////////////////////
 final case class DFVector(
     cellType: DFType,
-    cellDims: List[Int]
+    cellDimParamRefs: List[IntParamRef]
 ) extends ComposedDFType:
   type Data = Vector[Any]
-  def width(using MemberGetSet): Int = cellType.width * cellDims.product
-  def createBubbleData(using MemberGetSet): Data = Vector.fill(cellDims.head)(
+  def width(using MemberGetSet): Int = cellType.width * cellDimParamRefs.map(_.getInt).product
+  // TODO: change for multidimensional arrays
+  def length(using MemberGetSet): Int = cellDimParamRefs.head.getInt
+  def createBubbleData(using MemberGetSet): Data = Vector.fill(length)(
     cellType.createBubbleData
   )
   def isDataBubble(data: Data): Boolean =
@@ -240,7 +242,7 @@ final case class DFVector(
         )
     seq.toVector
   protected def `prot_=~`(that: DFType)(using MemberGetSet): Boolean = this equals that
-  def getRefs: List[DFRef.TwoWayAny] = Nil
+  def getRefs: List[DFRef.TwoWayAny] = cellDimParamRefs.flatMap(_.getRef)
 end DFVector
 
 object DFVector extends DFType.Companion[DFVector, Vector[Any]]

--- a/compiler/ir/src/main/scala/dfhdl/compiler/printing/DFTypePrinter.scala
+++ b/compiler/ir/src/main/scala/dfhdl/compiler/printing/DFTypePrinter.scala
@@ -88,7 +88,9 @@ protected trait DFTypePrinter extends AbstractTypePrinter:
   def csDFEnum(dfType: DFEnum, typeCS: Boolean): String = dfType.getName
   def csDFVector(dfType: DFVector, typeCS: Boolean): String =
     import dfType.*
-    val dimStr = if (cellDims.size == 1) cellDims.head.toString else cellDims.mkStringBrackets
+    val dimStr =
+      if (cellDimParamRefs.size == 1) cellDimParamRefs.head.refCodeString
+      else cellDimParamRefs.map(_.refCodeString).mkStringBrackets
     s"${csDFType(cellType, typeCS)} X $dimStr"
   def csDFOpaqueDcl(dfType: DFOpaque): String =
     val csActualType = csDFType(dfType.actualType)

--- a/compiler/stages/src/main/scala/dfhdl/compiler/stages/ExplicitClkRstCfg.scala
+++ b/compiler/stages/src/main/scala/dfhdl/compiler/stages/ExplicitClkRstCfg.scala
@@ -13,7 +13,7 @@ import scala.collection.mutable
 case object ExplicitClkRstCfg extends Stage:
   def dependencies: List[Stage] = List()
   def nullifies: Set[Stage] = Set()
-  def transform(designDB: DB)(using getSet: MemberGetSet, co: CompilerOptions): DB =
+  def transform(designDB: DB)(using MemberGetSet, CompilerOptions): DB =
     val domainMap = mutable.Map.empty[DFDomainOwner, RTDomainCfg.Explicit]
     extension (owner: DFDomainOwner)
       def usesClk: Boolean = designDB.domainOwnerMemberTable(owner).exists {
@@ -44,7 +44,7 @@ case object ExplicitClkRstCfg extends Stage:
             case None =>
               val cfg =
                 if (currentOwner.isTop)
-                  RTDomainCfg.Explicit("main", co.defaultClkCfg, co.defaultRstCfg)
+                  currentOwner.getTagOf[RTDomainCfg.Explicit].get
                 else getExplicitCfg(currentOwner.getOwnerDomain)
               val updatedClkCfg: ClkCfg = if (currentOwner.usesClk) cfg.clkCfg else None
               val updatedRstCfg: RstCfg = if (currentOwner.usesRst) cfg.rstCfg else None

--- a/compiler/stages/src/main/scala/dfhdl/compiler/stages/verilog/VerilogPrinter.scala
+++ b/compiler/stages/src/main/scala/dfhdl/compiler/stages/verilog/VerilogPrinter.scala
@@ -56,7 +56,7 @@ class VerilogPrinter(using val getSet: MemberGetSet, val printerOptions: Printer
   def alignCode(cs: String): String =
     cs
       // align after port modifiers
-      .align("[ ]*(?:input|output|inout).*", " ", ".*")
+      .align("[ ]*(?:input|output|inout)", " ", ".*")
       // align after wire/reg/logic words
       .align(
         "\\s*(?:logic(?: signed)?\\s*\\[\\d+:\\d+]|[\\w]+)",

--- a/compiler/stages/src/main/scala/dfhdl/compiler/stages/verilog/VerilogTypePrinter.scala
+++ b/compiler/stages/src/main/scala/dfhdl/compiler/stages/verilog/VerilogTypePrinter.scala
@@ -35,8 +35,9 @@ protected trait VerilogTypePrinter extends AbstractTypePrinter:
   def csDFEnum(dfType: DFEnum, typeCS: Boolean): String = csDFEnumTypeName(dfType)
   def csDFVectorRanges(dfType: DFType): String =
     dfType match
-      case vec: DFVector => s" [0:${vec.cellDims.head - 1}]${csDFVectorRanges(vec.cellType)}"
-      case _             => ""
+      case vec: DFVector =>
+        s" [0:${vec.cellDimParamRefs.head.uboundCS}]${csDFVectorRanges(vec.cellType)}"
+      case _ => ""
   def csDFVector(dfType: DFVector, typeCS: Boolean): String =
     import dfType.*
     s"${csDFType(cellType, typeCS)}"

--- a/compiler/stages/src/main/scala/dfhdl/compiler/stages/vhdl/VHDLTypePrinter.scala
+++ b/compiler/stages/src/main/scala/dfhdl/compiler/stages/vhdl/VHDLTypePrinter.scala
@@ -187,7 +187,7 @@ protected trait VHDLTypePrinter extends AbstractTypePrinter:
       while (inVector)
         loopType match
           case dfType: DFVector =>
-            desc = desc + s"(0 to ${dfType.cellDims.head} - 1)"
+            desc = desc + s"(0 to ${dfType.cellDimParamRefs.head.uboundCS})"
             loopType = dfType.cellType
           case cellType =>
             val finale = cellType match

--- a/compiler/stages/src/main/scala/dfhdl/compiler/stages/vhdl/VHDLValPrinter.scala
+++ b/compiler/stages/src/main/scala/dfhdl/compiler/stages/vhdl/VHDLValPrinter.scala
@@ -92,7 +92,7 @@ protected trait VHDLValPrinter extends AbstractValPrinter:
 
               // all args are the same ==> repeat function
               case _ if args.view.map(_.get).forall(_ =~ args.head.get) =>
-                s"(0 to ${args.length}-1 => ${args.head.refCodeString.applyBrackets()})"
+                s"(0 to ${args.length - 1} => ${args.head.refCodeString.applyBrackets()})"
 
               case DFVector(_, _) =>
                 args.map(_.refCodeString).mkStringBrackets
@@ -116,7 +116,7 @@ protected trait VHDLValPrinter extends AbstractValPrinter:
       while (inVector)
         loopType match
           case dfType: DFVector =>
-            desc = s"$desc, ${dfType.cellDims.head}"
+            desc = s"$desc, ${dfType.cellDimParamRefs.head.refCodeString}"
             loopType = dfType.cellType
           case cellType =>
             val finale = cellType match

--- a/compiler/stages/src/main/scala/dfhdl/hw/hw.scala
+++ b/compiler/stages/src/main/scala/dfhdl/hw/hw.scala
@@ -1,4 +1,0 @@
-package dfhdl.hw
-
-final case class top()(using dfhdl.options.CompilerOptions) extends HWAnnotation:
-  val isActive = true

--- a/compiler/stages/src/main/scala/dfhdl/options/CompilerOptions.scala
+++ b/compiler/stages/src/main/scala/dfhdl/options/CompilerOptions.scala
@@ -11,8 +11,6 @@ final case class CompilerOptions(
     newFolderForTop: NewFolderForTop,
     backend: Backend,
     logLevel: LogLevel,
-    defaultClkCfg: DefaultClkCfg,
-    defaultRstCfg: DefaultRstCfg,
     printDesignCodeBefore: PrintDesignCodeBefore,
     printDesignCodeAfter: PrintDesignCodeAfter,
     printGenFiles: PrintGenFiles
@@ -23,17 +21,14 @@ object CompilerOptions:
       newFolderForTop: NewFolderForTop,
       backend: Backend,
       logLevel: LogLevel,
-      defaultClkCfg: DefaultClkCfg = ClkCfg(ClkCfg.Edge.Rising),
-      defaultRstCfg: DefaultRstCfg = RstCfg(RstCfg.Mode.Sync, RstCfg.Active.High),
       printDesignCodeBefore: PrintDesignCodeBefore,
       printDesignCodeAfter: PrintDesignCodeAfter,
       printGenFiles: PrintGenFiles
   ): CompilerOptions =
     CompilerOptions(
       commitFolder = commitFolder, newFolderForTop = newFolderForTop, backend = backend,
-      logLevel = logLevel, defaultClkCfg = defaultClkCfg, defaultRstCfg = defaultRstCfg,
-      printDesignCodeBefore = printDesignCodeBefore, printDesignCodeAfter = printDesignCodeAfter,
-      printGenFiles = printGenFiles
+      logLevel = logLevel, printDesignCodeBefore = printDesignCodeBefore,
+      printDesignCodeAfter = printDesignCodeAfter, printGenFiles = printGenFiles
     )
 
   extension (co: CompilerOptions)
@@ -64,14 +59,6 @@ object CompilerOptions:
   object LogLevel:
     given (using logLevel: dfhdl.options.LogLevel): LogLevel = logLevel
     export dfhdl.options.LogLevel.*
-
-  opaque type DefaultClkCfg <: ClkCfg = ClkCfg
-  given Conversion[ClkCfg, DefaultClkCfg] = identity
-  given Conversion[None.type, DefaultClkCfg] = x => x.asInstanceOf[DefaultClkCfg]
-
-  opaque type DefaultRstCfg <: RstCfg = RstCfg
-  given Conversion[RstCfg, DefaultRstCfg] = identity
-  given Conversion[None.type, DefaultRstCfg] = x => x.asInstanceOf[DefaultRstCfg]
 
   opaque type PrintDesignCodeBefore <: Boolean = Boolean
   object PrintDesignCodeBefore:

--- a/compiler/stages/src/main/scala/dfhdl/options/CompilerOptions.scala
+++ b/compiler/stages/src/main/scala/dfhdl/options/CompilerOptions.scala
@@ -1,17 +1,16 @@
 package dfhdl.options
-import CompilerOptions.*
 import dfhdl.compiler.ir
 import dfhdl.compiler.stages.BackendCompiler
 import dfhdl.core.{ClkCfg, RstCfg}
-export wvlet.log.LogLevel
 
 import java.io.File.separatorChar
 
+import CompilerOptions.*
 final case class CompilerOptions(
     commitFolder: CommitFolder,
     newFolderForTop: NewFolderForTop,
     backend: Backend,
-    logLevel: CompilerLogLevel,
+    logLevel: LogLevel,
     defaultClkCfg: DefaultClkCfg,
     defaultRstCfg: DefaultRstCfg,
     printDesignCodeBefore: PrintDesignCodeBefore,
@@ -20,15 +19,15 @@ final case class CompilerOptions(
 )
 object CompilerOptions:
   given default(using
-      commitFolder: CommitFolder = "sandbox",
-      newFolderForTop: NewFolderForTop = true,
-      backend: Backend = dfhdl.backends.verilog.sv2005,
-      logLevel: CompilerLogLevel = LogLevel.WARN,
+      commitFolder: CommitFolder,
+      newFolderForTop: NewFolderForTop,
+      backend: Backend,
+      logLevel: LogLevel,
       defaultClkCfg: DefaultClkCfg = ClkCfg(ClkCfg.Edge.Rising),
       defaultRstCfg: DefaultRstCfg = RstCfg(RstCfg.Mode.Sync, RstCfg.Active.High),
-      printDesignCodeBefore: PrintDesignCodeBefore = false,
-      printDesignCodeAfter: PrintDesignCodeAfter = false,
-      printGenFiles: PrintGenFiles = false
+      printDesignCodeBefore: PrintDesignCodeBefore,
+      printDesignCodeAfter: PrintDesignCodeAfter,
+      printGenFiles: PrintGenFiles
   ): CompilerOptions =
     CompilerOptions(
       commitFolder = commitFolder, newFolderForTop = newFolderForTop, backend = backend,
@@ -45,16 +44,26 @@ object CompilerOptions:
       s"${co.topCommitPath(stagedDB)}${separatorChar}hdl"
 
   opaque type CommitFolder <: String = String
-  given Conversion[String, CommitFolder] = identity
+  object CommitFolder:
+    given CommitFolder = "sandbox"
+    given Conversion[String, CommitFolder] = identity
 
   opaque type NewFolderForTop <: Boolean = Boolean
-  given Conversion[Boolean, NewFolderForTop] = identity
+  object NewFolderForTop:
+    given NewFolderForTop = true
+    given Conversion[Boolean, NewFolderForTop] = identity
 
   opaque type Backend <: BackendCompiler = BackendCompiler
-  given Conversion[BackendCompiler, Backend] = identity
+  object Backend:
+    given Backend = dfhdl.backends.verilog.sv2005
+    given Conversion[BackendCompiler, Backend] = identity
+    export dfhdl.backends.*
 
-  opaque type CompilerLogLevel <: LogLevel = LogLevel
-  given Conversion[LogLevel, CompilerLogLevel] = identity
+  opaque type LogLevel <: dfhdl.options.LogLevel = dfhdl.options.LogLevel
+  given Conversion[wvlet.log.LogLevel, LogLevel] = x => x.asInstanceOf[LogLevel]
+  object LogLevel:
+    given (using logLevel: dfhdl.options.LogLevel): LogLevel = logLevel
+    export dfhdl.options.LogLevel.*
 
   opaque type DefaultClkCfg <: ClkCfg = ClkCfg
   given Conversion[ClkCfg, DefaultClkCfg] = identity
@@ -65,11 +74,17 @@ object CompilerOptions:
   given Conversion[None.type, DefaultRstCfg] = x => x.asInstanceOf[DefaultRstCfg]
 
   opaque type PrintDesignCodeBefore <: Boolean = Boolean
-  given Conversion[Boolean, PrintDesignCodeBefore] = identity
+  object PrintDesignCodeBefore:
+    given PrintDesignCodeBefore = false
+    given Conversion[Boolean, PrintDesignCodeBefore] = identity
 
   opaque type PrintDesignCodeAfter <: Boolean = Boolean
-  given Conversion[Boolean, PrintDesignCodeAfter] = identity
+  object PrintDesignCodeAfter:
+    given PrintDesignCodeAfter = false
+    given Conversion[Boolean, PrintDesignCodeAfter] = identity
 
   opaque type PrintGenFiles <: Boolean = Boolean
-  given Conversion[Boolean, PrintGenFiles] = identity
+  object PrintGenFiles:
+    given PrintGenFiles = false
+    given Conversion[Boolean, PrintGenFiles] = identity
 end CompilerOptions

--- a/compiler/stages/src/test/scala/StagesSpec/DropDesignDefsSpec.scala
+++ b/compiler/stages/src/test/scala/StagesSpec/DropDesignDefsSpec.scala
@@ -12,6 +12,7 @@ class DropDesignDefsSpec extends StageSpec:
 
       /** This is my test
         * @param arg
+        *   is a nice param
         * @return
         */
       def test(arg: UInt[32] <> VAL): UInt[32] <> DFRET =
@@ -24,9 +25,11 @@ class DropDesignDefsSpec extends StageSpec:
       id,
       """|/** This is my test
          |  * @param arg
+         |  *   is a nice param
          |  * @return
          |  **/
          |class test extends DFDesign:
+         |  /**is a nice param*/
          |  val arg = UInt(32) <> IN
          |  val o = UInt(32) <> OUT
          |  o <> arg + arg

--- a/compiler/stages/src/test/scala/StagesSpec/PrintVHDLCodeSpec.scala
+++ b/compiler/stages/src/test/scala/StagesSpec/PrintVHDLCodeSpec.scala
@@ -308,7 +308,7 @@ class PrintVHDLCodeSpec extends StageSpec:
          |  constant c13 : unsigned(7 downto 0) := unsigned'(x"--");
          |  constant c14 : signed(7 downto 0) := signed'(x"--");
          |  constant c15 : t_struct_DFTuple2 := t_struct_DFTuple2(_1 = "000", _2 = '1');
-         |  constant c16 : t_vecX2_std_logic_vector(0 to 7 - 1)(0 to 5 - 1)(7 downto 0) := (0 to 7-1 => (x"00", x"11", x"22", x"33", x"44"));
+         |  constant c16 : t_vecX2_std_logic_vector(0 to 6)(0 to 4)(7 downto 0) := (0 to 6 => (x"00", x"11", x"22", x"33", x"44"));
          |begin
          |
          |end Top_arch;
@@ -478,7 +478,7 @@ class PrintVHDLCodeSpec extends StageSpec:
          |    end loop;
          |    return ret;
          |  end;
-         |  subtype t_opaque_Foo is t_vecX2_std_logic_vector(0 to 10 - 1)(0 to 16 - 1)(11 downto 0);
+         |  subtype t_opaque_Foo is t_vecX2_std_logic_vector(0 to 9)(0 to 15)(11 downto 0);
          |  function to_t_opaque_Foo(A : std_logic_vector) return t_opaque_Foo is
          |  begin
          |    return to_t_vecX2_std_logic_vector(A, 10, 16, 12);
@@ -495,7 +495,7 @@ class PrintVHDLCodeSpec extends StageSpec:
          |  process (clk)
          |  begin
          |    if rising_edge(clk) then
-         |      if rst = '1' then v <= (0 to 10-1 => (0 to 16-1 => x"000"));
+         |      if rst = '1' then v <= (0 to 9 => (0 to 15 => x"000"));
          |      else v <= v_din;
          |      end if;
          |    end if;
@@ -518,7 +518,7 @@ class PrintVHDLCodeSpec extends StageSpec:
          |
          |entity Example is
          |port (
-         |  v : out t_vecX2_std_logic_vector(0 to 10 - 1)(0 to 16 - 1)(11 downto 0)
+         |  v : out t_vecX2_std_logic_vector(0 to 9)(0 to 15)(11 downto 0)
          |);
          |end Example;
          |
@@ -526,7 +526,7 @@ class PrintVHDLCodeSpec extends StageSpec:
          |begin
          |  process (all)
          |  begin
-         |    v <= (0 to 10-1 => (0 to 16-1 => x"000"));
+         |    v <= (0 to 9 => (0 to 15 => x"000"));
          |  end process;
          |end Example_arch;
          |""".stripMargin
@@ -543,7 +543,7 @@ class PrintVHDLCodeSpec extends StageSpec:
     // TODO: consider if we want to leave the t_opaque_Foo under `getCompiledCodeString`
     assertNoDiff(
       top,
-      """|subtype t_opaque_Foo is t_vecX2_std_logic_vector(0 to 10 - 1)(0 to 16 - 1)(11 downto 0);
+      """|subtype t_opaque_Foo is t_vecX2_std_logic_vector(0 to 9)(0 to 15)(11 downto 0);
          |
          |library ieee;
          |use ieee.std_logic_1164.all;
@@ -570,7 +570,7 @@ class PrintVHDLCodeSpec extends StageSpec:
          |  process (clk)
          |  begin
          |    if rising_edge(clk) then
-         |      if rst = '1' then y <= (0 to 10-1 => (0 to 16-1 => x"000"));
+         |      if rst = '1' then y <= (0 to 9 => (0 to 15 => x"000"));
          |      else y <= y_din;
          |      end if;
          |    end if;

--- a/compiler/stages/src/test/scala/StagesSpec/PrintVerilogCodeSpec.scala
+++ b/compiler/stages/src/test/scala/StagesSpec/PrintVerilogCodeSpec.scala
@@ -227,10 +227,10 @@ class PrintVerilogCodeSpec extends StageSpec:
          |`include "Top_defs.sv"
          |
          |module Top(
-         |  input wire logic        clk,
-         |  input wire logic        rst,
-         |  input wire logic [15:0] x,
-         |  output logic [15:0]     y
+         |  input  wire logic clk,
+         |  input  wire logic rst,
+         |  input  wire logic [15:0] x,
+         |  output logic [15:0] y
          |);
          |  parameter logic [15:0] c = 16'h0000;
          |  logic [15:0] z;

--- a/core/src/main/scala/dfhdl/compiler/patching/MetaDesign.scala
+++ b/core/src/main/scala/dfhdl/compiler/patching/MetaDesign.scala
@@ -23,6 +23,8 @@ abstract class MetaDesign[+D <: DomainType](
   final override private[dfhdl] def initOwner: Design.Block =
     dfc.mutableDB.addMember(injectedOwner)
     injectedOwner.getThisOrOwnerDesign.asFE
+  final override protected def __dfc: DFC = DFC.empty
+
   injectedOwner match
     case design: ir.DFDesignBlock => // do nothing
     case _ =>

--- a/core/src/main/scala/dfhdl/core/Container.scala
+++ b/core/src/main/scala/dfhdl/core/Container.scala
@@ -5,7 +5,9 @@ import dfhdl.compiler.ir
 private trait Container extends OnCreateEvents, HasDFC:
   type This <: Container
   final lazy val dfc: DFC = __dfc
-  protected def __dfc: DFC = DFC.empty
+  protected def __dfc: DFC =
+    println("Severe error: missing DFHDL context!\nMake sure you enable the DFHDL compiler plugin.")
+    sys.exit(1)
   private[core] type TScope <: DFC.Scope
   private[core] type TDomain <: DomainType
   private[core] type TOwner <: DFOwnerAny

--- a/core/src/main/scala/dfhdl/core/DFBoolOrBit.scala
+++ b/core/src/main/scala/dfhdl/core/DFBoolOrBit.scala
@@ -147,3 +147,6 @@ final lazy val DFBool = ir.DFBool.asFE[DFBool]
 type DFBit = DFType[ir.DFBit.type, NoArgs]
 final lazy val DFBit = ir.DFBit.asFE[DFBit]
 given CanEqual[DFBoolOrBit, DFBoolOrBit] = CanEqual.derived
+
+type DFConstBool = DFConstOf[DFBool]
+type DFConstBit = DFConstOf[DFBit]

--- a/core/src/main/scala/dfhdl/core/DFC.scala
+++ b/core/src/main/scala/dfhdl/core/DFC.scala
@@ -1,6 +1,7 @@
 package dfhdl.core
 import dfhdl.internals.*
 import dfhdl.compiler.ir
+import dfhdl.options.ElaborationOptions
 import ir.{HWAnnotation, getActiveHWAnnotations}
 
 import scala.annotation.Annotation
@@ -11,7 +12,7 @@ final case class DFC(
     docOpt: Option[String],
     annotations: List[HWAnnotation] = Nil, // TODO: removing default causes stale symbol crash
     mutableDB: MutableDB = new MutableDB(),
-    defaultDir: Int = 0
+    elaborationOptions: ElaborationOptions = ElaborationOptions.default
 ) extends MetaContext:
   def setMeta(
       nameOpt: Option[String] = nameOpt,
@@ -52,7 +53,6 @@ final case class DFC(
   def setAnnotations(annotations: List[HWAnnotation]): this.type =
     copy(annotations = annotations).asInstanceOf[this.type]
   def anonymize: this.type = copy(nameOpt = None).asInstanceOf[this.type]
-  def <>(that: Int): this.type = copy(defaultDir = that).asInstanceOf[this.type]
   def logError(err: DFError): Unit = mutableDB.logger.logError(err)
   def getErrors: List[DFError] = mutableDB.logger.getErrors
   def inMetaProgramming: Boolean = mutableDB.inMetaProgramming
@@ -60,9 +60,10 @@ final case class DFC(
 end DFC
 object DFC:
   // DFC given must be inline to force new DFC is generated for every missing DFC summon.
-  inline given dfc: DFC = empty // (using TopLevel)
-  def empty: DFC =
-    DFC(None, Position.unknown, None)
+  inline given dfc(using ElaborationOptions): DFC = empty // (using TopLevel)
+  def empty(using eo: ElaborationOptions): DFC =
+    DFC(None, Position.unknown, None, elaborationOptions = eo)
+  def emptyNoEO: DFC = DFC(None, Position.unknown, None)
   sealed trait Scope
   object Scope:
     sealed trait Design extends Scope

--- a/core/src/main/scala/dfhdl/core/DFDecimal.scala
+++ b/core/src/main/scala/dfhdl/core/DFDecimal.scala
@@ -1080,7 +1080,7 @@ object DFXInt:
           arithOp(dfType, FuncOp.`*`, lhsVal, rhsVal)
         }
       end extension
-      extension [L](lhs: L)
+      extension [L <: Int](lhs: L)
         def +[RS <: Boolean, RW <: IntP, RN <: NativeType, RP](
             rhs: DFValTP[DFXInt[RS, RW, RN], RP]
         )(using sL: Exact.Summon[L, lhs.type])(using

--- a/core/src/main/scala/dfhdl/core/DFEnum.scala
+++ b/core/src/main/scala/dfhdl/core/DFEnum.scala
@@ -5,8 +5,7 @@ import scala.quoted.*
 import collection.immutable.ListMap
 import ir.DFVal.Func.Op as FuncOp
 
-sealed abstract class DFEncoding extends DFVal[Nothing, Nothing], scala.reflect.Enum:
-  val irValue: ir.DFVal | DFError = DFError.FakeEnum
+sealed abstract class DFEncoding extends scala.reflect.Enum:
   def calcWidth(entryCount: Int): Int
   def encode(idx: Int): BigInt
   def bigIntValue: BigInt

--- a/core/src/main/scala/dfhdl/core/DFError.scala
+++ b/core/src/main/scala/dfhdl/core/DFError.scala
@@ -3,6 +3,7 @@ import dfhdl.compiler.ir
 import dfhdl.internals.*
 
 import scala.annotation.targetName
+import dfhdl.options.OnError
 
 sealed abstract class DFError(
     val dfMsg: String
@@ -116,6 +117,10 @@ def trydf(block: => Unit)(using dfc: DFC, ctName: CTName): Unit =
           exitWithError(dfErr.toString())
         dfc.logError(dfErr)
 
-def exitWithError(msg: String): Nothing =
+def exitWithError(msg: String)(using DFC): Nothing =
   System.err.println(msg)
-  sys.exit(1)
+  dfc.elaborationOptions.onError match
+    case OnError.Exit =>
+      sys.exit(1)
+    case _ =>
+      throw new IllegalArgumentException("Elaboration errors found!")

--- a/core/src/main/scala/dfhdl/core/DFOpaque.scala
+++ b/core/src/main/scala/dfhdl/core/DFOpaque.scala
@@ -71,7 +71,7 @@ object DFOpaque:
       private def asDFVector[A <: DFTypeAny](dfVals: Iterable[DFValOf[A]])(using
           DFC
       ): DFValOf[DFVector[A, Tuple1[Int]]] =
-        val dfType = DFVector(dfVals.head.dfType, List(dfVals.size))
+        val dfType = DFVector[A, Tuple1[Int]](dfVals.head.dfType, List(dfVals.size))
         DFVal.Func(dfType, DFVal.Func.Op.++, dfVals.toList)
       extension [A <: DFTypeAny](lhs: Iterable[DFValOf[A]])
         transparent inline def as[Comp <: AnyRef](

--- a/core/src/main/scala/dfhdl/core/DFOpaque.scala
+++ b/core/src/main/scala/dfhdl/core/DFOpaque.scala
@@ -71,7 +71,7 @@ object DFOpaque:
       private def asDFVector[A <: DFTypeAny](dfVals: Iterable[DFValOf[A]])(using
           DFC
       ): DFValOf[DFVector[A, Tuple1[Int]]] =
-        val dfType = DFVector(dfVals.head.dfType, Tuple1(dfVals.size))
+        val dfType = DFVector(dfVals.head.dfType, List(dfVals.size))
         DFVal.Func(dfType, DFVal.Func.Op.++, dfVals.toList)
       extension [A <: DFTypeAny](lhs: Iterable[DFValOf[A]])
         transparent inline def as[Comp <: AnyRef](

--- a/core/src/main/scala/dfhdl/core/DFType.scala
+++ b/core/src/main/scala/dfhdl/core/DFType.scala
@@ -96,12 +96,12 @@ object DFType:
           modifier: M
       ): DFVector.ComposedModifier[D, M] =
         new DFVector.ComposedModifier[D, M](cellDim, modifier)
-    extension (cellDim: Int)
+    extension [D <: IntP](cellDim: D)
       @targetName("composeMod")
       infix def <>[M <: ModifierAny](
           modifier: M
-      ): DFVector.ComposedModifier[Int, M] =
-        new DFVector.ComposedModifier[Int, M](cellDim, modifier)
+      ): DFVector.ComposedModifier[D, M] =
+        new DFVector.ComposedModifier[D, M](cellDim, modifier)
     extension [T <: Supported](t: T)
       infix def <>[A, C, I, P](modifier: Modifier[A, C, I, P])(using
           dfc: DFC,

--- a/core/src/main/scala/dfhdl/core/DFType.scala
+++ b/core/src/main/scala/dfhdl/core/DFType.scala
@@ -94,13 +94,15 @@ object DFType:
     extension [D <: Int & Singleton](cellDim: D)
       infix def <>[M <: ModifierAny](
           modifier: M
-      ): DFVector.ComposedModifier[D, M] =
+      )(using dfc: DFC, check: DFVector.VectorLength.Check[D]): DFVector.ComposedModifier[D, M] =
+        check(cellDim)
         new DFVector.ComposedModifier[D, M](cellDim, modifier)
     extension [D <: IntP](cellDim: D)
       @targetName("composeMod")
       infix def <>[M <: ModifierAny](
           modifier: M
-      ): DFVector.ComposedModifier[D, M] =
+      )(using dfc: DFC, check: DFVector.VectorLength.CheckNUB[D]): DFVector.ComposedModifier[D, M] =
+        check(IntParam.fromValue(cellDim))
         new DFVector.ComposedModifier[D, M](cellDim, modifier)
     extension [T <: Supported](t: T)
       infix def <>[A, C, I, P](modifier: Modifier[A, C, I, P])(using

--- a/core/src/main/scala/dfhdl/core/DFType.scala
+++ b/core/src/main/scala/dfhdl/core/DFType.scala
@@ -89,7 +89,8 @@ object DFType:
 
   given [T <: DFTypeAny]: CanEqual[T, T] = CanEqual.derived
 
-  type Supported = DFTypeAny | DFEncoding | DFOpaqueA | Byte | Int | Long | Boolean | AnyRef | Unit
+  type Supported = DFTypeAny | NonEmptyTuple | DFStruct.Fields | DFEncoding | DFOpaqueA | Byte |
+    Int | Long | Boolean | Object | Unit
   object Ops:
     extension [D <: Int & Singleton](cellDim: D)
       infix def <>[M <: ModifierAny](

--- a/core/src/main/scala/dfhdl/core/DFVal.scala
+++ b/core/src/main/scala/dfhdl/core/DFVal.scala
@@ -54,7 +54,8 @@ extension (using quotes: Quotes)(tpe: quotes.reflect.TypeRepr)
       case '[DFValOf[t]]   => false
       case '[NonEmptyTuple] =>
         tpe.getTupleArgs.forall(isConstBool)
-      case _ => true
+      case '[SameElementsVector[t]] => isConstBool(TypeRepr.of[t])
+      case _                        => true
     if (isConstBool(tpe)) TypeRepr.of[CONST]
     else TypeRepr.of[NOTCONST]
 
@@ -99,7 +100,7 @@ infix type <>[T <: DFType.Supported, M] = T match
 
 infix type X[T <: DFType.Supported, M] = M match
   case DFVector.ComposedModifier[d, m] => <>[DFVector[DFType.Of[T], Tuple1[d]], m]
-  case Int & Singleton                 => DFVector[DFType.Of[T], Tuple1[M]]
+  case _                               => DFVector[DFType.Of[T], Tuple1[M]]
 type JUSTVAL[T <: DFType.Supported] = <>[T, VAL]
 
 extension [V <: ir.DFVal](dfVal: V)
@@ -226,9 +227,9 @@ sealed protected trait DFValLP:
   }
   implicit transparent inline def DFVectorValConversion[
       T <: DFTypeAny,
-      D <: Int,
+      D <: IntP,
       P <: Boolean,
-      R <: DFValAny | Iterable[?] | Bubble
+      R <: DFValAny | Iterable[?] | SameElementsVector[?] | Bubble
   ](
       inline from: R
   ): DFValTP[DFVector[T, Tuple1[D]], ISCONST[P]] = ${

--- a/core/src/main/scala/dfhdl/core/DFVal.scala
+++ b/core/src/main/scala/dfhdl/core/DFVal.scala
@@ -14,6 +14,7 @@ import dfhdl.compiler.printing.{DefaultPrinter, Printer}
 import scala.annotation.tailrec
 
 import scala.reflect.ClassTag
+
 trait DFVal[+T <: DFTypeAny, +M <: ModifierAny] extends Any with DFMember[ir.DFVal] with Selectable:
 
   def selectDynamic(name: String)(using DFC): Any = trydf {
@@ -312,6 +313,8 @@ object DFVal extends DFValLP:
   given [T <: DFTypeAny, M <: ModifierAny]: CanEqual[Boolean, DFVal[T, M]] =
     CanEqual.derived
   given [T <: DFTypeAny, M <: ModifierAny]: CanEqual[Tuple, DFVal[T, M]] =
+    CanEqual.derived
+  given [T <: DFTypeAny, M <: ModifierAny]: CanEqual[DFEncoding, DFVal[T, M]] =
     CanEqual.derived
 
   given __refined_dfVal[T <: FieldsOrTuple, A, I, P](using

--- a/core/src/main/scala/dfhdl/core/DFVector.scala
+++ b/core/src/main/scala/dfhdl/core/DFVector.scala
@@ -13,19 +13,29 @@ type DFVector[+T <: DFTypeAny, +D <: NonEmptyTuple] =
 object DFVector:
   def apply[T <: DFTypeAny, D <: NonEmptyTuple](
       cellType: T,
-      cellDims: D
-  ): DFVector[T, D] =
-    ir.DFVector(cellType.asIR, cellDims.toList.asInstanceOf[List[Int]])
+      cellDims: List[IntParam[Int]]
+  )(using DFC): DFVector[T, D] =
+    ir.DFVector(cellType.asIR, cellDims.map(_.ref))
       .asFE[DFVector[T, D]]
   @targetName("givenApply")
   given apply[T <: DFTypeAny, D <: NonEmptyTuple](using
+      dfc: DFC,
       cellType: T,
       cellDims: ValueOfTuple[D]
-  ): DFVector[T, D] = DFVector(cellType, cellDims.value)
+  ): DFVector[T, D] =
+    DFVector(
+      cellType,
+      cellDims.value.toList.asInstanceOf[List[IntP]].map(x => IntParam.fromValue(x))
+    )
 
   extension [T <: DFTypeAny, D <: NonEmptyTuple](dfType: DFVector[T, D])
     def cellType: T = dfType.asIR.cellType.asFE[T]
-    def cellDims: List[Int] = dfType.asIR.cellDims
+  extension [T <: DFTypeAny, D1 <: IntP](dfType: DFVector[T, Tuple1[D1]])
+    def lengthInt(using dfc: DFC): Int =
+      import dfc.getSet
+      dfType.asIR.cellDimParamRefs.head.getInt
+    def lengthIntParam(using dfc: DFC): IntParam[D1] =
+      dfType.asIR.cellDimParamRefs.head.get.asInstanceOf[IntParam[D1]]
 
   protected[core] object IndexWidth
       extends Check2[
@@ -44,20 +54,23 @@ object DFVector:
           ") is different than the receiver vector length (" + LL + ")."
       ]
 
-  sealed class ComposedModifier[D <: Int, M](val cellDim: D, val modifier: M)
+  sealed class ComposedModifier[D <: IntP, M](val cellDim: D, val modifier: M)
   object Ops:
-    extension [T <: DFType.Supported, D <: Int](t: T)(using tc: DFType.TC[T])
+    extension [T <: DFType.Supported, D <: IntP](t: T)(using tc: DFType.TC[T])
       // transparent inline def X(inline cellDim: Int*): DFType =
       //   x(dfType, cellDim*)
       inline infix def X(
-          cellDim: Inlined[D]
+          cellDim: IntParam[D]
       )(using DFC): DFVector[tc.Type, Tuple1[D]] =
-        DFVector(tc(t), Tuple1(cellDim))
-    extension [T <: DFType.Supported, D <: Int, M <: ModifierAny](t: T)(using tc: DFType.TC[T])
+        DFVector[tc.Type, Tuple1[D]](tc(t), List(cellDim))
+    extension [T <: DFType.Supported, D <: IntP, M <: ModifierAny](t: T)(using tc: DFType.TC[T])
       infix def X(
           composedModifier: ComposedModifier[D, M]
       )(using DFC): DFVal[DFVector[tc.Type, Tuple1[D]], M] =
-        DFVal.Dcl(DFVector(tc(t), Tuple1(composedModifier.cellDim)), composedModifier.modifier)
+        DFVal.Dcl(
+          DFVector(tc(t), List(IntParam.fromValue(composedModifier.cellDim))),
+          composedModifier.modifier
+        )
 //      inline def X(
 //          inline cellDim0: Int,
 //          inline cellDim1: Int
@@ -81,20 +94,20 @@ object DFVector:
       import DFVal.TC
       given DFVectorValFromDFVectorVal[
           T <: DFTypeAny,
-          D1 <: Int,
-          RD1 <: Int,
+          D1 <: IntP,
+          RD1 <: IntP,
           RP,
           R <: DFValTP[DFVector[T, Tuple1[RD1]], RP]
       ](using
-          check: `LL == RL`.Check[D1, RD1]
+          check: `LL == RL`.CheckNUB[D1, RD1]
       ): TC[DFVector[T, Tuple1[D1]], R] with
         type OutP = RP
         def conv(dfType: DFVector[T, Tuple1[D1]], arg: R)(using DFC): Out =
-          check(dfType.asIR.cellDims.head, arg.dfType.asIR.cellDims.head)
+          check(dfType.lengthInt, arg.dfType.lengthInt)
           arg.asValTP[DFVector[T, Tuple1[D1]], RP]
       given DFVectorValFromDFValVector[
           T <: DFTypeAny,
-          D1 <: Int,
+          D1 <: IntP,
           E,
           R <: Iterable[E],
           TCE <: TC[T, E]
@@ -107,7 +120,7 @@ object DFVector:
           DFVal.Func(dfType, FuncOp.++, dfVals)
       given DFVectorValFromSEV[
           T <: DFTypeAny,
-          D1 <: Int,
+          D1 <: IntP,
           E,
           R <: SameElementsVector[E],
           TCE <: TC[T, E]
@@ -117,15 +130,15 @@ object DFVector:
         type OutP = tc.OutP
         def conv(dfType: DFVector[T, Tuple1[D1]], arg: R)(using DFC): Out =
           val dfVals =
-            List.fill(dfType.cellDims.head)(tc.conv(dfType.cellType, arg.value))
-          DFVal.Func(dfType, FuncOp.++, dfVals)(using dfc.anonymize)
+            List.fill(dfType.lengthInt)(tc.conv(dfType.cellType, arg.value))
+          DFVal.Func(dfType, FuncOp.++, dfVals)
       end DFVectorValFromSEV
     end TC
     object Compare:
       import DFVal.Compare
       given DFVectorCompareDFValVector[
           T <: DFTypeAny,
-          D1 <: Int,
+          D1 <: IntP,
           E,
           R <: Iterable[E],
           Op <: FuncOp,
@@ -139,11 +152,11 @@ object DFVector:
         type OutP = tc.OutP
         def conv(dfType: DFVector[T, Tuple1[D1]], arg: R)(using DFC): Out =
           val dfVals = arg.view.map(tc.conv(dfType.cellType, _)).toList
-          DFVal.Func(dfType, FuncOp.++, dfVals)(using dfc.anonymize)
+          DFVal.Func(dfType, FuncOp.++, dfVals)
       end DFVectorCompareDFValVector
     end Compare
     object Ops:
-      extension [T <: DFTypeAny, D1 <: Int, M <: ModifierAny](
+      extension [T <: DFTypeAny, D1 <: IntP, M <: ModifierAny](
           lhs: DFVal[DFVector[T, Tuple1[D1]], M]
       )
         @targetName("applyDFVector")
@@ -153,13 +166,13 @@ object DFVector:
             c: DFUInt.Val.UBArg[D1, I],
             dfc: DFC
         ): DFVal[T, M] = trydf {
-          val idxVal = c(IntParam.forced[D1](lhs.dfType.cellDims.head), idx)(using dfc.anonymize)
+          val idxVal = c(lhs.dfType.lengthIntParam, idx)(using dfc.anonymize)
           DFVal.Alias.ApplyIdx(lhs.dfType.cellType, lhs, idxVal)
         }
         def elements(using DFC): Vector[DFValOf[T]] =
           import DFDecimal.StrInterpOps.d
           val elementType = lhs.dfType.cellType
-          Vector.tabulate(lhs.dfType.cellDims.head)(i =>
+          Vector.tabulate(lhs.dfType.lengthInt)(i =>
             val idxVal = DFVal.Const(DFInt32, Some(BigInt(i)))
             DFVal.Alias.ApplyIdx(elementType, lhs, idxVal)(using dfc.anonymize)
           )

--- a/core/src/main/scala/dfhdl/core/Design.scala
+++ b/core/src/main/scala/dfhdl/core/Design.scala
@@ -70,13 +70,19 @@ object Design:
   type Block = DFOwner[ir.DFDesignBlock]
   object Block:
     def apply(domain: ir.DomainType, dclMeta: ir.Meta, instMode: InstMode)(using DFC): Block =
+      // top level is tagged with the default RT Domain configuration
+      // (the top level may be an ED or DF design, so it cannot save the default RT configuration as part
+      // of the domain type, but this could be needed later for compilation stages)
+      val tags =
+        if (dfc.ownerOption.isEmpty) ir.DFTags.empty.tag(dfc.elaborationOptions.defaultRTDomainCfg)
+        else ir.DFTags.empty
       ir.DFDesignBlock(
         domain,
         dclMeta,
         instMode,
         dfc.ownerOrEmptyRef,
         dfc.getMeta,
-        ir.DFTags.empty
+        tags
       )
         .addMember
         .asFE

--- a/core/src/main/scala/dfhdl/core/Timer.scala
+++ b/core/src/main/scala/dfhdl/core/Timer.scala
@@ -3,6 +3,7 @@ import dfhdl.compiler.ir
 import ir.{Time, Freq, Ratio}
 import ir.Timer.Func.Op as FuncOp
 import dfhdl.internals.*
+import scala.annotation.targetName
 
 sealed class Timer private (val irValue: ir.Timer | DFError) extends DFMember[ir.Timer]
 object Timer:
@@ -14,6 +15,7 @@ object Timer:
       case f: Freq => f.period
 
   def apply()(using DFC): Timer = Periodic(None, None)
+  @targetName("applyPeriod")
   def apply(period: Period)(using DFC): Timer = Periodic(None, Some(period.time))
   def apply(trigger: DFValOf[DFBit])(using DFC): Timer = Periodic(Some(trigger), None)
   def apply(trigger: DFValOf[DFBit], period: Period)(using DFC): Timer =

--- a/core/src/main/scala/dfhdl/options/ElaborationOptions.scala
+++ b/core/src/main/scala/dfhdl/options/ElaborationOptions.scala
@@ -1,13 +1,15 @@
 package dfhdl.options
 import dfhdl.core.{ClkCfg, RstCfg}
-
+import dfhdl.compiler.ir.RTDomainCfg
 import ElaborationOptions.*
 final case class ElaborationOptions(
     logLevel: LogLevel,
     onError: OnError,
     defaultClkCfg: DefaultClkCfg,
     defaultRstCfg: DefaultRstCfg
-)
+):
+  val defaultRTDomainCfg: RTDomainCfg.Explicit =
+    RTDomainCfg.Explicit("main", defaultClkCfg, defaultRstCfg)
 object ElaborationOptions:
   given default(using
       logLevel: LogLevel,

--- a/core/src/main/scala/dfhdl/options/ElaborationOptions.scala
+++ b/core/src/main/scala/dfhdl/options/ElaborationOptions.scala
@@ -1,0 +1,50 @@
+package dfhdl.options
+import dfhdl.core.{ClkCfg, RstCfg}
+
+import ElaborationOptions.*
+final case class ElaborationOptions(
+    logLevel: LogLevel,
+    onError: OnError,
+    defaultClkCfg: DefaultClkCfg,
+    defaultRstCfg: DefaultRstCfg
+)
+object ElaborationOptions:
+  given default(using
+      logLevel: LogLevel,
+      onError: OnError,
+      defaultClkCfg: DefaultClkCfg,
+      defaultRstCfg: DefaultRstCfg
+  ): ElaborationOptions =
+    ElaborationOptions(
+      logLevel = logLevel,
+      onError = onError,
+      defaultClkCfg = defaultClkCfg,
+      defaultRstCfg = defaultRstCfg
+    )
+
+  opaque type LogLevel <: dfhdl.options.LogLevel = dfhdl.options.LogLevel
+  object LogLevel:
+    given Conversion[wvlet.log.LogLevel, LogLevel] = x => x.asInstanceOf[LogLevel]
+    given (using logLevel: dfhdl.options.LogLevel): LogLevel = logLevel
+    export dfhdl.options.LogLevel.*
+
+  opaque type OnError <: dfhdl.options.OnError = dfhdl.options.OnError
+  object OnError:
+    given (using onError: dfhdl.options.OnError): OnError = onError
+    given Conversion[dfhdl.options.OnError, OnError] = x => x.asInstanceOf[OnError]
+    export dfhdl.options.OnError.*
+
+  opaque type DefaultClkCfg <: ClkCfg = ClkCfg
+  object DefaultClkCfg:
+    given DefaultClkCfg = ClkCfg(ClkCfg.Edge.Rising)
+    given Conversion[ClkCfg, DefaultClkCfg] = identity
+    given Conversion[None.type, DefaultClkCfg] = x => x.asInstanceOf[DefaultClkCfg]
+    export ClkCfg.*
+
+  opaque type DefaultRstCfg <: RstCfg = RstCfg
+  object DefaultRstCfg:
+    given DefaultRstCfg = RstCfg(RstCfg.Mode.Sync, RstCfg.Active.High)
+    given Conversion[RstCfg, DefaultRstCfg] = identity
+    given Conversion[None.type, DefaultRstCfg] = x => x.asInstanceOf[DefaultRstCfg]
+    export RstCfg.*
+end ElaborationOptions

--- a/core/src/main/scala/dfhdl/options/LogLevel.scala
+++ b/core/src/main/scala/dfhdl/options/LogLevel.scala
@@ -1,0 +1,8 @@
+package dfhdl.options
+import wvlet.log.LogLevel as wvletLogLevel
+
+opaque type LogLevel <: wvletLogLevel = wvletLogLevel
+given Conversion[wvletLogLevel, LogLevel] = x => x.asInstanceOf[LogLevel]
+object LogLevel:
+  export wvletLogLevel.{OFF, ERROR, WARN, INFO, DEBUG, TRACE, ALL}
+  given LogLevel = wvletLogLevel.WARN

--- a/core/src/main/scala/dfhdl/options/OnError.scala
+++ b/core/src/main/scala/dfhdl/options/OnError.scala
@@ -1,6 +1,10 @@
 package dfhdl.options
+import dfhdl.internals.getShellCommand
 
 enum OnError derives CanEqual:
   case Exit, Exception
 object OnError:
-  given OnError = OnError.Exit
+  private lazy val sbtShellIsRunning = getShellCommand match
+    case Some(cmd) if cmd.endsWith("xsbt.boot.Boot") => true
+    case _                                           => false
+  given OnError = if (sbtShellIsRunning) Exception else Exit

--- a/core/src/test/scala/CoreSpec/DFDecimalSpec.scala
+++ b/core/src/test/scala/CoreSpec/DFDecimalSpec.scala
@@ -306,14 +306,14 @@ class DFDecimalSpec extends DFSpec:
       val value = 1000
       u8 > value
     }
-    assertRuntimeError(
+    assertRuntimeErrorLog(
       """|Cannot apply this operation between an unsigned value (LHS) and a signed value (RHS).
          |An explicit conversion must be applied.
          |""".stripMargin
     ) {
       u8 == negOne
     }
-    assertRuntimeError(
+    assertRuntimeErrorLog(
       """|Cannot apply this operation between a value of 8 bits width (LHS) to a value of 10 bits width (RHS).
          |An explicit conversion must be applied.
          |""".stripMargin
@@ -321,7 +321,7 @@ class DFDecimalSpec extends DFSpec:
       u8 == big
     }
     // TODO: this fails with the wrong message (sign mismatch)
-    // assertRuntimeError(
+    // assertRuntimeErrorLog(
     //   """|Cannot apply this operation between a value of 8 bits width (LHS) to a value of 10 bits width (RHS).
     //      |An explicit conversion must be applied.
     //      |""".stripMargin

--- a/core/src/test/scala/CoreSpec/DFIfSpec.scala
+++ b/core/src/test/scala/CoreSpec/DFIfSpec.scala
@@ -173,7 +173,7 @@ class DFIfSpec extends DFSpec:
     }
   }
   test("Different return widths error") {
-    assertRuntimeError(
+    assertRuntimeErrorLog(
       """|This DFHDL `if` expression has different return types for branches.
          |These are its branch types in order:
          |Bits(2)

--- a/core/src/test/scala/CoreSpec/DFStructSpec.scala
+++ b/core/src/test/scala/CoreSpec/DFStructSpec.scala
@@ -63,7 +63,7 @@ class DFStructSpec extends DFSpec:
     val nine = 9
     val cc5 = new CCs(nine)
     val t5 = cc5.XY <> VAR
-    assertRuntimeError(
+    assertRuntimeErrorLog(
       """|Mismatch in structure fields.
          |The applied value type is:
          |final case class XY(

--- a/core/src/test/scala/CoreSpec/DFVectorSpec.scala
+++ b/core/src/test/scala/CoreSpec/DFVectorSpec.scala
@@ -22,6 +22,11 @@ class DFVectorSpec extends DFSpec:
          |v3 := all(all(d"8'0"))
          |v3(3)(1) := d"8'25"
          |v3 := v3
+         |val len: Int <> CONST = 3
+         |val v4 = UInt(8) X len <> VAR init all(d"8'0")
+         |val v5: UInt[4] X len <> CONST = all(d"4'0")
+         |val v6 = UInt(4) X len <> VAR init v5
+         |v6 := all(d"4'0")
          |""".stripMargin
     ) {
       val v1 = UInt(8) X 5 <> VAR init Vector.tabulate(5)(22 + _)
@@ -57,6 +62,11 @@ class DFVectorSpec extends DFSpec:
       v3(3)(1) := 25
       val t: UInt[8] X 4 X 4 <> VAL = v3
       v3 := t
+      val len: Int <> CONST = 3
+      val v4 = UInt(8) X len <> VAR init all(0)
+      val v5: (UInt[4] X len.type) <> CONST = all(0)
+      val v6 = UInt(4) X len <> VAR init v5
+      v6 := all(0)
     }
   }
   test("Big Endian Packed Order") {

--- a/core/src/test/scala/CoreSpec/DFVectorSpec.scala
+++ b/core/src/test/scala/CoreSpec/DFVectorSpec.scala
@@ -83,18 +83,27 @@ class DFVectorSpec extends DFSpec:
       ) {
         val v7 = UInt(4) X zero X 5 <> VAR
       }
-      val zeroP: Int <> CONST = 0
-      assertDSLError(
+      assertCompileError(
         "The vector length must be positive but found: 0"
       )(
         """val v7: UInt[4] X 0 <> CONST = all(0)"""
+      )
+      // TODO: does not compile, since (zero.type <> CONST) is not considered for vector composition.
+      // Attempts to fix it resulted in match type failure to reduce. Maybe in the future this can be
+      // resolved.
+      // assertRuntimeError(
+      //   "The vector length must be positive but found: 0"
+      // ){
+      //   val v7: UInt[4] X zero.type <> CONST = all(0)
+      // }
+      val zeroP: Int <> CONST = 0
+      assertRuntimeError(
+        "The vector length must be positive but found: 0"
       ) {
         val v7: UInt[4] X zeroP.type <> CONST = all(0)
       }
-      assertDSLError(
+      assertRuntimeError(
         "The vector length must be positive but found: 0"
-      )(
-        """val v7: UInt[4] X 0 X 5 <> CONST = all(all(0))"""
       ) {
         val v7: UInt[4] X zeroP.type X 5 <> CONST = all(all(0))
       }

--- a/core/src/test/scala/CoreSpec/DFVectorSpec.scala
+++ b/core/src/test/scala/CoreSpec/DFVectorSpec.scala
@@ -27,6 +27,7 @@ class DFVectorSpec extends DFSpec:
          |val v5: UInt[4] X len <> CONST = all(d"4'0")
          |val v6 = UInt(4) X len <> VAR init v5
          |v6 := all(d"4'0")
+         |val zeroP: Int <> CONST = 0
          |""".stripMargin
     ) {
       val v1 = UInt(8) X 5 <> VAR init Vector.tabulate(5)(22 + _)
@@ -67,6 +68,36 @@ class DFVectorSpec extends DFSpec:
       val v5: UInt[4] X len.type <> CONST = all(0)
       val v6 = UInt(4) X len <> VAR init v5
       v6 := all(0)
+      val zero = 0
+      assertDSLError(
+        "The vector length must be positive but found: 0"
+      )(
+        """val v7 = UInt(4) X 0 <> VAR"""
+      ) {
+        val v7 = UInt(4) X zero <> VAR
+      }
+      assertDSLError(
+        "The vector length must be positive but found: 0"
+      )(
+        """val v7 = UInt(4) X 0 X 5 <> VAR"""
+      ) {
+        val v7 = UInt(4) X zero X 5 <> VAR
+      }
+      val zeroP: Int <> CONST = 0
+      assertDSLError(
+        "The vector length must be positive but found: 0"
+      )(
+        """val v7: UInt[4] X 0 <> CONST = all(0)"""
+      ) {
+        val v7: UInt[4] X zeroP.type <> CONST = all(0)
+      }
+      assertDSLError(
+        "The vector length must be positive but found: 0"
+      )(
+        """val v7: UInt[4] X 0 X 5 <> CONST = all(all(0))"""
+      ) {
+        val v7: UInt[4] X zeroP.type X 5 <> CONST = all(all(0))
+      }
     }
   }
   test("Big Endian Packed Order") {

--- a/core/src/test/scala/CoreSpec/DFVectorSpec.scala
+++ b/core/src/test/scala/CoreSpec/DFVectorSpec.scala
@@ -64,7 +64,7 @@ class DFVectorSpec extends DFSpec:
       v3 := t
       val len: Int <> CONST = 3
       val v4 = UInt(8) X len <> VAR init all(0)
-      val v5: (UInt[4] X len.type) <> CONST = all(0)
+      val v5: UInt[4] X len.type <> CONST = all(0)
       val v6 = UInt(4) X len <> VAR init v5
       v6 := all(0)
     }

--- a/core/src/test/scala/DFSpec.scala
+++ b/core/src/test/scala/DFSpec.scala
@@ -49,6 +49,14 @@ abstract class DFSpec extends FunSuite, AllowTopLevel, HasTypeName, HasDFC:
   end assertCompileError
 
   inline def assertRuntimeError(expectedErr: String)(runTimeCode: => Unit): Unit =
+    val err =
+      try
+        runTimeCode
+        noErrMsg
+      catch case e: IllegalArgumentException => e.getMessage
+    assertNoDiff(err, expectedErr)
+
+  inline def assertRuntimeErrorLog(expectedErr: String)(runTimeCode: => Unit): Unit =
     dfc.clearErrors()
     runTimeCode
     val err = dfc.getErrors.headOption.map(_.dfMsg).getOrElse(noErrMsg)
@@ -58,12 +66,7 @@ abstract class DFSpec extends FunSuite, AllowTopLevel, HasTypeName, HasDFC:
       inline compileTimeCode: String
   )(runTimeCode: => Unit): Unit =
     assertCompileError(expectedErr)(compileTimeCode)
-    val err =
-      try
-        runTimeCode
-        noErrMsg
-      catch case e: IllegalArgumentException => e.getMessage
-    assertNoDiff(err, expectedErr)
+    assertRuntimeError(expectedErr)(runTimeCode)
 
   def assertEquals[T <: DFType, L <: DFConstOf[T], R <: DFConstOf[T]](l: L, r: R): Unit =
     assert((l == r).toScalaBoolean)

--- a/docs/getting-started/hello-world/scala-cli-project/Counter8.scala
+++ b/docs/getting-started/hello-world/scala-cli-project/Counter8.scala
@@ -6,6 +6,12 @@ class Counter8 extends RTDesign:
   cnt.din := cnt + 1
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
+// DFHDL Elaboration Options:                                                                 //
+////////////////////////////////////////////////////////////////////////////////////////////////
+// Uncomment to set different clock and reset configurations:
+// given options.ElaborationOptions.DefaultClkCfg = ClkCfg(ClkCfg.Edge.Rising)
+// given options.ElaborationOptions.DefaultRstCfg = RstCfg(RstCfg.Mode.Async, RstCfg.Active.Low)
+////////////////////////////////////////////////////////////////////////////////////////////////
 // DFHDL Compiler Options:                                                                    //
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // Enables printing the generated chosen backend code:
@@ -16,9 +22,6 @@ given options.CompilerOptions.PrintGenFiles = true
 // given options.CompilerOptions.PrintDesignCodeBefore = true
 // Uncomment to enable printing design code after compilation:
 // given options.CompilerOptions.PrintDesignCodeAfter = true
-// Uncomment to set different clock and reset configurations:
-// given options.CompilerOptions.DefaultClkCfg = ClkCfg(ClkCfg.Edge.Rising)
-// given options.CompilerOptions.DefaultRstCfg = RstCfg(RstCfg.Mode.Async, RstCfg.Active.Low)
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 //The entry point to your compilation program starts here

--- a/docs/getting-started/hello-world/scala-cli-single-file/Counter8.scala
+++ b/docs/getting-started/hello-world/scala-cli-single-file/Counter8.scala
@@ -11,6 +11,12 @@ class Counter8 extends RTDesign:
   cnt.din := cnt + 1
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
+// DFHDL Elaboration Options:                                                                 //
+////////////////////////////////////////////////////////////////////////////////////////////////
+// Uncomment to set different clock and reset configurations:
+// given options.ElaborationOptions.DefaultClkCfg = ClkCfg(ClkCfg.Edge.Rising)
+// given options.ElaborationOptions.DefaultRstCfg = RstCfg(RstCfg.Mode.Async, RstCfg.Active.Low)
+////////////////////////////////////////////////////////////////////////////////////////////////
 // DFHDL Compiler Options:                                                                    //
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // Enables printing the generated chosen backend code:
@@ -21,9 +27,6 @@ given options.CompilerOptions.PrintGenFiles = true
 // given options.CompilerOptions.PrintDesignCodeBefore = true
 // Uncomment to enable printing design code after compilation:
 // given options.CompilerOptions.PrintDesignCodeAfter = true
-// Uncomment to set different clock and reset configurations:
-// given options.CompilerOptions.DefaultClkCfg = ClkCfg(ClkCfg.Edge.Rising)
-// given options.CompilerOptions.DefaultRstCfg = RstCfg(RstCfg.Mode.Async, RstCfg.Active.Low)
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 //The entry point to your compilation program starts here

--- a/lib/src/main/scala/dfhdl/DFApp.scala
+++ b/lib/src/main/scala/dfhdl/DFApp.scala
@@ -12,10 +12,14 @@ trait DFApp:
   logger.info(s"Welcome to DFiant HDL (DFHDL) v$dfhdlVersion !!!")
   private var designName: String = ""
   private var topScalaPath: String = ""
+  // this context is just for enabling `getParamData` to work.
+  // the internal global context inside `value` will be actually at play here.
+  val dfc: DFC = DFC.emptyNoEO
   case class Arg(name: String, typeName: String, value: Any, desc: String):
     def valueStr: String = value match
       case dfConst: DFValAny =>
-        dfConst.asIR.asInstanceOf[ir.DFVal.Const].data.asInstanceOf[Option[Any]].get.toString()
+        import dfc.getSet
+        dfConst.asIR.getParamData.asInstanceOf[Option[Option[Any]]].get.get.toString()
       case _ => value.toString()
     def updateWithValueStr(updatedValueStr: String): Arg =
       val scalaTypeName = typeName.replaceFirst("DFHDL ", "")

--- a/lib/src/main/scala/dfhdl/DFApp.scala
+++ b/lib/src/main/scala/dfhdl/DFApp.scala
@@ -1,0 +1,170 @@
+package dfhdl
+import scala.collection.immutable.ListMap
+import dfhdl.core
+import core.{DFValAny, asValAny}
+import dfhdl.compiler.ir
+import wvlet.log.{Logger, LogFormatter}
+import scala.collection.mutable
+import scala.annotation.static
+trait DFApp:
+  private val logger = Logger("DFHDL App")
+  logger.setFormatter(LogFormatter.BareFormatter)
+  logger.info(s"Welcome to DFiant HDL (DFHDL) v$dfhdlVersion !!!")
+  private var designName: String = ""
+  private var topScalaPath: String = ""
+  case class Arg(name: String, typeName: String, value: Any, desc: String):
+    def valueStr: String = value match
+      case dfConst: DFValAny =>
+        dfConst.asIR.asInstanceOf[ir.DFVal.Const].data.asInstanceOf[Option[Any]].get.toString()
+      case _ => value.toString()
+    def updateWithValueStr(updatedValueStr: String): Arg =
+      val scalaTypeName = typeName.replaceFirst("DFHDL ", "")
+      val updatedValueScala = scalaTypeName match
+        case "Int"    => BigInt(updatedValueStr)
+        case "Double" => updatedValueStr.toDouble
+        case "Boolean" | "Bit" =>
+          updatedValueStr match
+            case "1" => true
+            case "0" => false
+            case _   => updatedValueStr.toBoolean
+        case _ => updatedValueStr
+
+      val updatedValue = value match
+        case dfConst: DFValAny =>
+          core.DFVal.Const.forced(dfConst.dfType, Some(updatedValueScala))
+        case _ => updatedValueScala
+      copy(value = updatedValue)
+    end updateWithValueStr
+  end Arg
+
+  private var designArgs: ListMap[String, Arg] = ListMap.empty
+  private var elaborationOptions: options.ElaborationOptions = null
+  private var compilerOptions: options.CompilerOptions = null
+  private var printerOptions: options.PrinterOptions = null
+  private var linterOptions: options.LinterOptions = null
+  private var dsn: () => core.Design = null
+  private var mode = "commit"
+  final protected def getDsnArg(name: String): Any =
+    designArgs(name).value
+  final protected def setInitials(
+      _designName: String,
+      _topScalaPath: String,
+      top: dfhdl.top,
+      argNames: List[String],
+      argTypes: List[String],
+      argValues: List[Any],
+      argDescs: List[String]
+  ): Unit =
+    designName = _designName
+    topScalaPath = _topScalaPath
+    elaborationOptions = top.elaborationOptions
+    compilerOptions = top.compilerOptions
+    printerOptions = top.printerOptions
+    designArgs = ListMap.from(
+      argNames.lazyZip(argTypes).lazyZip(argValues).lazyZip(argDescs).map(
+        (name, typeName, value, desc) => name -> Arg(name, typeName, value, desc)
+      )
+    )
+  end setInitials
+  final protected def setDsn(d: => core.Design): Unit = dsn = () => d
+  private def elaborate: core.Design =
+    logger.info("Elaborating design...")
+    dsn()
+
+  private def programName: String =
+    dfhdl.internals.getShellCommand match
+      // sbt
+      case Some(cmd) if cmd.contains("xsbt.boot.Boot") =>
+        if (cmd.endsWith("xsbt.boot.Boot")) s"runMain $topScalaPath"
+        else s"""sbt "runMain $topScalaPath [options]""""
+      // scala-cli
+      case Some(cmd) if cmd.contains(".scala-build") =>
+        s"scala-cli run . -M $topScalaPath --"
+      case _ =>
+        "<your program>"
+  private lazy val parser = new scopt.OptionParser[Unit](programName):
+    override def terminate(exitState: Either[String, Unit]): Unit = ()
+    def optDesignArg = opt[Map[String, String]]("design-args")
+      .abbr("da")
+      .valueName("a1=v1,a2=v2...")
+      .validate(x =>
+        val invalidKeys = x.keySet -- designArgs.keySet
+        if (invalidKeys.nonEmpty)
+          failure(s"Unrecognized design arguments: ${invalidKeys.mkString(", ")}")
+        else
+          val typeMismatches = x.flatMap((argName, updatedValueStr) =>
+            val isValid =
+              designArgs(argName).typeName match
+                case "String" | "DFHDL String" => true
+                case "Int" | "DFHDL Int"       => updatedValueStr.toIntOption.nonEmpty
+                case "Double" | "DFHDL Double" => updatedValueStr.toDoubleOption.nonEmpty
+                case "Boolean" | "Bit" | "DFHDL Boolean" | "DFHDL Bit" =>
+                  updatedValueStr.toBooleanOption.nonEmpty || updatedValueStr == "1" || updatedValueStr == "0"
+                case _ => false
+            if (isValid) None
+            else Some(argName)
+          )
+          if (typeMismatches.nonEmpty)
+            failure(s"Type mismatch in design arguments: ${typeMismatches.mkString(", ")}")
+          else success
+        end if
+      )
+      .foreach(_.foreach { (argName, updatedValueStr) =>
+        designArgs =
+          designArgs.updatedWith(argName)(ao => Some(ao.get.updateWithValueStr(updatedValueStr)))
+      })
+      .text("design arguments (run list-design-args command to get a full list)")
+    def optLinter =
+      val accepted = Set("verilator", "ghdl")
+      opt[String]("linter")
+        .validate(x =>
+          if (accepted.contains(x)) success
+          else failure(s"Acceptable values are: ${accepted.mkString(", ")}")
+        )
+        .text(s"linter tool: ${accepted.mkString(", ")}")
+    help("help").text("display usage text")
+    head(s"Design Name: $designName")
+    optDesignArg
+    cmd("list-design-args")
+      .text("Mode: List all design arguments")
+      .foreach(_ => mode = "list-design-args")
+    cmd("elaborate")
+      .foreach(_ => mode = "elaborate")
+      .text("Mode: Elaboration only (no compilation)")
+    cmd("compile")
+      .foreach(_ => mode = "compile")
+      .text("Mode: Compilation (after elaboration, and WITHOUT committing files to disk)")
+    cmd("commit")
+      .foreach(_ => mode = "commit")
+      .text("Mode: Committing to disk (after elaboration and compilation) [default]")
+    cmd("lint")
+      .foreach(_ => mode = "lint")
+      .text("Mode: Linting (after elaboration, compilation, and committing to disk)")
+      .children(optLinter)
+
+  private def listDesignArgs: Unit =
+    logger.info("Design arguments:")
+    val titles = f"${"Name"}%-20s${"Type"}%-20s${"Default"}%-20sDescription"
+    println(titles)
+    println("-" * titles.length)
+    designArgs.values.foreach(a =>
+      println(f"${a.name}%-20s${a.typeName}%-20s${a.valueStr}%-20s${a.desc}")
+    )
+
+  def main(args: Array[String]): Unit =
+    given options.ElaborationOptions = elaborationOptions
+    given options.CompilerOptions = compilerOptions
+    given options.PrinterOptions = printerOptions
+    if (parser.parse(args, ()).isDefined)
+      mode match
+        case "elaborate" =>
+          elaborate
+        case "compile" =>
+          elaborate.compile
+        case "commit" =>
+          elaborate.compile.commit
+        case "list-design-args" =>
+          listDesignArgs
+        case _ =>
+  end main
+end DFApp

--- a/lib/src/main/scala/dfhdl/DFApp.scala
+++ b/lib/src/main/scala/dfhdl/DFApp.scala
@@ -48,8 +48,13 @@ trait DFApp:
   private var linterOptions: options.LinterOptions = null
   private var dsn: () => core.Design = null
   private var mode = "commit"
+  // used by the plugin to get the updated design arguments that could be changed by the
+  // command-line options
   final protected def getDsnArg(name: String): Any =
     designArgs(name).value
+  // used by the plugin to get the updated elaboration options that could be changed by the
+  // command-line options
+  final protected def getElaborationOptions: options.ElaborationOptions = elaborationOptions
   final protected def setInitials(
       _designName: String,
       _topScalaPath: String,
@@ -73,6 +78,7 @@ trait DFApp:
   final protected def setDsn(d: => core.Design): Unit = dsn = () => d
   private def elaborate: core.Design =
     logger.info("Elaborating design...")
+    // the elaboration options are set in the compiler plugin using getElaborationOptions
     dsn()
 
   private def programName: String =
@@ -147,7 +153,7 @@ trait DFApp:
       .children(optLinter)
 
   private def listDesignArgs: Unit =
-    logger.info("Design arguments:")
+    println("Design arguments:")
     val titles = f"${"Name"}%-20s${"Type"}%-20s${"Default"}%-20sDescription"
     println(titles)
     println("-" * titles.length)
@@ -156,7 +162,6 @@ trait DFApp:
     )
 
   def main(args: Array[String]): Unit =
-    given options.ElaborationOptions = elaborationOptions
     given options.CompilerOptions = compilerOptions
     given options.PrinterOptions = printerOptions
     if (parser.parse(args, ()).isDefined)

--- a/lib/src/main/scala/dfhdl/options/BuilderOptions.scala
+++ b/lib/src/main/scala/dfhdl/options/BuilderOptions.scala
@@ -8,7 +8,7 @@ trait BuilderOptions extends ToolOptions:
 //defaults common for all linting tools
 object BuilderOptions:
   opaque type OnError <: dfhdl.options.ToolOptions.OnError = dfhdl.options.ToolOptions.OnError
-  given Conversion[dfhdl.options.OnError, OnError] = x => x.asInstanceOf[OnError]
   object OnError:
     given (using onError: dfhdl.options.ToolOptions.OnError): OnError = onError
+    given Conversion[dfhdl.options.OnError, OnError] = x => x.asInstanceOf[OnError]
     export dfhdl.options.OnError.*

--- a/lib/src/main/scala/dfhdl/options/GHDLOptions.scala
+++ b/lib/src/main/scala/dfhdl/options/GHDLOptions.scala
@@ -15,13 +15,13 @@ object GHDLOptions:
   ): GHDLOptions = GHDLOptions(onError = onError, warnAsError = warnAsError)
 
   opaque type OnError <: LinterOptions.OnError = LinterOptions.OnError
-  given Conversion[dfhdl.options.OnError, OnError] = x => x.asInstanceOf[OnError]
   object OnError:
     given (using onError: LinterOptions.OnError): OnError = onError
+    given Conversion[dfhdl.options.OnError, OnError] = x => x.asInstanceOf[OnError]
     export dfhdl.options.OnError.*
 
   opaque type WarnAsError <: LinterOptions.WarnAsError = LinterOptions.WarnAsError
-  given Conversion[LinterOptions.WarnAsError, WarnAsError] = identity
   object WarnAsError:
+    given Conversion[LinterOptions.WarnAsError, WarnAsError] = identity
     given (using warnAsError: LinterOptions.WarnAsError): WarnAsError = warnAsError
 end GHDLOptions

--- a/lib/src/main/scala/dfhdl/options/LinterOptions.scala
+++ b/lib/src/main/scala/dfhdl/options/LinterOptions.scala
@@ -9,12 +9,12 @@ trait LinterOptions extends ToolOptions:
 //defaults common for all linting tools
 object LinterOptions:
   opaque type OnError <: dfhdl.options.ToolOptions.OnError = dfhdl.options.ToolOptions.OnError
-  given Conversion[dfhdl.options.OnError, OnError] = x => x.asInstanceOf[OnError]
   object OnError:
     given (using onError: dfhdl.options.ToolOptions.OnError): OnError = onError
+    given Conversion[dfhdl.options.OnError, OnError] = x => x.asInstanceOf[OnError]
     export dfhdl.options.OnError.*
 
   opaque type WarnAsError <: Boolean = Boolean
-  given Conversion[Boolean, WarnAsError] = identity
   object WarnAsError:
     given WarnAsError = false
+    given Conversion[Boolean, WarnAsError] = identity

--- a/lib/src/main/scala/dfhdl/options/ToolOptions.scala
+++ b/lib/src/main/scala/dfhdl/options/ToolOptions.scala
@@ -6,8 +6,8 @@ trait ToolOptions:
 //defaults common for all tools
 object ToolOptions:
   opaque type OnError <: dfhdl.options.OnError = dfhdl.options.OnError
-  given Conversion[dfhdl.options.OnError, OnError] = identity
   object OnError:
     given (using onError: dfhdl.options.OnError): OnError = onError
+    given Conversion[dfhdl.options.OnError, OnError] = identity
     export dfhdl.options.OnError.*
 end ToolOptions

--- a/lib/src/main/scala/dfhdl/options/VerilatorOptions.scala
+++ b/lib/src/main/scala/dfhdl/options/VerilatorOptions.scala
@@ -18,13 +18,13 @@ object VerilatorOptions:
   )
 
   opaque type OnError <: LinterOptions.OnError = LinterOptions.OnError
-  given Conversion[dfhdl.options.OnError, OnError] = x => x.asInstanceOf[OnError]
   object OnError:
     given (using onError: LinterOptions.OnError): OnError = onError
+    given Conversion[dfhdl.options.OnError, OnError] = x => x.asInstanceOf[OnError]
     export dfhdl.options.OnError.*
 
   opaque type WarnAsError <: LinterOptions.WarnAsError = LinterOptions.WarnAsError
-  given Conversion[LinterOptions.WarnAsError, WarnAsError] = identity
   object WarnAsError:
     given (using warnAsError: LinterOptions.WarnAsError): WarnAsError = warnAsError
+    given Conversion[LinterOptions.WarnAsError, WarnAsError] = identity
 end VerilatorOptions

--- a/lib/src/main/scala/dfhdl/top.scala
+++ b/lib/src/main/scala/dfhdl/top.scala
@@ -1,0 +1,7 @@
+package dfhdl
+
+final case class top(genMain: Boolean = true)(using
+    val elaborationOptions: dfhdl.options.ElaborationOptions,
+    val compilerOptions: dfhdl.options.CompilerOptions,
+    val printerOptions: dfhdl.options.PrinterOptions
+) extends scala.annotation.StaticAnnotation

--- a/lib/src/test/scala/AES/Cipher.scala
+++ b/lib/src/test/scala/AES/Cipher.scala
@@ -8,5 +8,5 @@ class Cipher extends DFDesign:
   o := cipher(data, key)
 
 @main def main: Unit =
-  given options.CompilerOptions.CompilerLogLevel = options.LogLevel.INFO
+  given options.CompilerOptions.LogLevel = options.LogLevel.INFO
   Cipher().printCodeString

--- a/lib/src/test/scala/AES/Cipher.scala
+++ b/lib/src/test/scala/AES/Cipher.scala
@@ -1,7 +1,7 @@
 package AES
 import dfhdl.*
 
-class Cipher extends DFDesign:
+@top(false) class Cipher extends DFDesign:
   val key = AESKey <> IN
   val data = AESData <> IN
   val o = AESData <> OUT

--- a/lib/src/test/scala/ArithSpec/PrioEncSpec.scala
+++ b/lib/src/test/scala/ArithSpec/PrioEncSpec.scala
@@ -5,7 +5,7 @@ import lib.arith.prioEnc
 
 class PrioEncSpec extends DesignSpec:
   test("Printing Encoder-32"):
-    class PrioTest extends DFDesign:
+    @top(false) class PrioTest extends DFDesign:
       val b32 = Bits(32) <> VAR
       val res = prioEnc(b32)
       res._2.verifyWidth(5)
@@ -63,7 +63,7 @@ class PrioEncSpec extends DesignSpec:
          |""".stripMargin
     )
   test("Printing Encoder-31"):
-    class PrioTest extends DFDesign:
+    @top(false) class PrioTest extends DFDesign:
       val b31 = Bits(31) <> VAR
       val res = prioEnc(b31)
       res._2.verifyWidth(5)

--- a/lib/src/test/scala/Example.scala
+++ b/lib/src/test/scala/Example.scala
@@ -3,7 +3,7 @@ import dfhdl.*
 enum ALUSel extends Encode:
   case ADD, SUB, SLL, SRL, SRA, AND, OR, XOR, SLT, SLTU, COPY1
 
-class ALU extends EDDesign:
+@top(false) class ALU extends EDDesign:
   // scalafmt: { align.tokens = [{code = "<>"}, {code = "="}, {code = "=>"}, {code = ":="}]}
   val op1    = Bits(32) <> IN
   val op2    = Bits(32) <> IN

--- a/lib/src/test/scala/issues/IssueSpec.scala
+++ b/lib/src/test/scala/issues/IssueSpec.scala
@@ -35,9 +35,9 @@ class IssuesSpec extends FunSuite:
          |  type t_vecX2_std_logic is array (natural range <>) of t_vecX1_std_logic;
          |  type t_vecX1_std_logic_vector is array (natural range <>) of std_logic_vector;
          |  type t_vecX2_std_logic_vector is array (natural range <>) of t_vecX1_std_logic_vector;
-         |  signal b : t_vecX1_std_logic(0 to 6 - 1);
-         |  signal c : t_vecX2_std_logic(0 to 4 - 1)(0 to 5 - 1);
-         |  signal d : t_vecX2_std_logic_vector(0 to 2 - 1)(0 to 3 - 1)(3 downto 0);
+         |  signal b : t_vecX1_std_logic(0 to 5);
+         |  signal c : t_vecX2_std_logic(0 to 3)(0 to 4);
+         |  signal d : t_vecX2_std_logic_vector(0 to 1)(0 to 2)(3 downto 0);
          |begin
          |  process (all)
          |  begin

--- a/lib/src/test/scala/issues/i116.scala
+++ b/lib/src/test/scala/issues/i116.scala
@@ -8,7 +8,7 @@ case class Test (
   b : Bit <> VAL
 ) extends Struct
 
-class GlobCounter (val width: Int <> CONST) extends RTDesign:
+@top(false) class GlobCounter (val width: Int <> CONST) extends RTDesign:
   val req = Bit <> IN
   val req2 = Bit <> IN
   val t = Test <> IN

--- a/lib/src/test/scala/issues/i118.scala
+++ b/lib/src/test/scala/issues/i118.scala
@@ -3,7 +3,7 @@ package issues.i118
 
 import dfhdl.*
 
-class ShiftIssue() extends RTDesign:  
+@top(false) class ShiftIssue() extends RTDesign:  
     val bitvec = Bits(10) <> VAR
     val bitvec2 = Bits(10) <> OUT
     val bitvec3 = Bits(10) <> VAR

--- a/lib/src/test/scala/issues/i126.scala
+++ b/lib/src/test/scala/issues/i126.scala
@@ -3,7 +3,7 @@ package issues.i126
 
 import dfhdl.*
 
-class TypeConvertIssue() extends RTDesign:
+@top(false) class TypeConvertIssue() extends RTDesign:
     val a = Bit <> IN
     val b = Bit <> IN
     val c = UInt(8) <> IN

--- a/lib/src/test/scala/issues/i128.scala
+++ b/lib/src/test/scala/issues/i128.scala
@@ -3,7 +3,7 @@ package issues.i128
 
 import dfhdl.*
 
-class ArrayIssue() extends RTDesign:
+@top(false) class ArrayIssue() extends RTDesign:
     val a = Bit <> IN
     val b = Bit X 6 <> VAR
     val c = Bit X 5 X 4 <> VAR

--- a/lib/src/test/scala/issues/i129.scala
+++ b/lib/src/test/scala/issues/i129.scala
@@ -3,7 +3,7 @@ package issues.i129
 
 import dfhdl.*
 
-class StdLogicConvIssue() extends RTDesign:
+@top(false) class StdLogicConvIssue() extends RTDesign:
     val a = Bits(10) <> IN
     val e = Bits(10) <> OUT
 

--- a/lib/src/test/scala/issues/i131.scala
+++ b/lib/src/test/scala/issues/i131.scala
@@ -3,7 +3,7 @@ package issues.i131
 
 import dfhdl.*
 
-class DictControl(
+@top(false) class DictControl(
     val fetch_count : Int <> CONST,  // set to 2
     val dict_entry_size : Int = 20
 ) extends RTDesign:

--- a/lib/src/test/scala/issues/i133.scala
+++ b/lib/src/test/scala/issues/i133.scala
@@ -3,7 +3,7 @@ package issues.i133
 
 import dfhdl.*
 
-class Width0Issue(val width : Int <> CONST) extends RTDesign:
+@top(false) class Width0Issue(val width : Int <> CONST) extends RTDesign:
     val d = Bit <> IN
     val a = Bits(width) <> VAR
     a(0) := d // works only when width > 1

--- a/lib/src/test/scala/issues/i135.scala
+++ b/lib/src/test/scala/issues/i135.scala
@@ -2,7 +2,7 @@
 package issues.i135
 
 import dfhdl._
-class VerilogSRA() extends RTDesign:
+@top(false) class VerilogSRA() extends RTDesign:
     val a = SInt(10) <> IN
     val b = SInt(10) <> VAR
     

--- a/lib/src/test/scala/issues/i141.scala
+++ b/lib/src/test/scala/issues/i141.scala
@@ -7,7 +7,7 @@ case class EmbeddedArray (
     a : Bits[8]X(3) <> VAL
 ) extends Struct
     
-class StructArrayIssue() extends RTDesign:
+@top(false) class StructArrayIssue() extends RTDesign:
     val a = Bit <> IN
     val e = EmbeddedArray <> VAR
     e.a(0)(0) := a

--- a/lib/src/test/scala/issues/i142.scala
+++ b/lib/src/test/scala/issues/i142.scala
@@ -3,7 +3,7 @@ package issues.i142
 
 import dfhdl._
 
-class IntegerIndexingIssue() extends RTDesign:
+@top(false) class IntegerIndexingIssue() extends RTDesign:
     val a = Bits(4) <> IN
     val b = Bits(12) X 16 <> VAR.REG init all(all(0))
     val c = Bits(12) <> OUT

--- a/lib/src/test/scala/issues/i146.scala
+++ b/lib/src/test/scala/issues/i146.scala
@@ -8,7 +8,7 @@ case class InStruct (
     b : Bit <> VAL
 ) extends Struct
 
-class DoubleStructDecl() extends RTDesign():
+@top(false) class DoubleStructDecl() extends RTDesign():
     val sin = InStruct <> IN
     val svar = InStruct <> VAR
     svar := sin

--- a/lib/src/test/scala/issues/i147.scala
+++ b/lib/src/test/scala/issues/i147.scala
@@ -14,7 +14,7 @@ class INV() extends RTDesign:
     c.din := a
     b := !a && c
     
-class ClockRstConnection() extends RTDesign(rtcfg):
+@top(false) class ClockRstConnection() extends RTDesign(rtcfg):
     val a = Bit <> IN
     val b = Bit <> OUT
     

--- a/plugin/src/main/scala-3.4-/plugin/Plugin.scala
+++ b/plugin/src/main/scala-3.4-/plugin/Plugin.scala
@@ -8,7 +8,8 @@ class Plugin extends StandardPlugin:
 
   def init(options: List[String]): List[PluginPhase] =
     val setting = new Setting(options.headOption)
-    MetaContextPlacerPhase(setting) ::
+    TopAnnotPhase(setting) ::
+      MetaContextPlacerPhase(setting) ::
       CustomControlPhase(setting) ::
       DesignDefsPhase(setting) ::
       MetaContextDelegatePhase(setting) ::

--- a/plugin/src/main/scala-3.5+/plugin/Plugin.scala
+++ b/plugin/src/main/scala-3.5+/plugin/Plugin.scala
@@ -9,7 +9,8 @@ class Plugin extends StandardPlugin:
 
   override def initialize(options: List[String])(using Context): List[PluginPhase] =
     val setting = new Setting(options.headOption)
-    MetaContextPlacerPhase(setting) ::
+    TopAnnotPhase(setting) ::
+      MetaContextPlacerPhase(setting) ::
       CustomControlPhase(setting) ::
       DesignDefsPhase(setting) ::
       MetaContextDelegatePhase(setting) ::

--- a/plugin/src/main/scala/plugin/MetaContextPlacerPhase.scala
+++ b/plugin/src/main/scala/plugin/MetaContextPlacerPhase.scala
@@ -33,7 +33,7 @@ class MetaContextPlacerPhase(setting: Setting) extends CommonPhase:
 
   val phaseName = "MetaContextPlacer"
 
-  override val runsAfter = Set("typer")
+  override val runsAfter = Set("TopAnnot")
   override val runsBefore = Set("FixInterpDFValPhase")
   // override val debugFilter: String => Boolean = _.contains("Example.scala")
   var dfcArgStack = List.empty[Tree]
@@ -99,6 +99,12 @@ class MetaContextPlacerPhase(setting: Setting) extends CommonPhase:
           dfcArgStack = dfcArgStack.drop(1)
         val clsTpe = tree.tpe
         val clsSym = clsTpe.classSymbol.asClass
+
+        // debug(tree.show)
+        // if (clsSym.companionClass.hasAnnotation(topAnnotSym) && false)
+        //   val newTemplate = cpy.Template(template)(body = genMainDef(clsSym) :: template.body)
+        //   cpy.TypeDef(tree)(rhs = newTemplate)
+        // else
         if (clsTpe <:< hasClsMetaArgsTpe && !clsSym.isAnonymousClass)
           val paramBody = template.body.takeWhile {
             case x: TypeDef                 => true
@@ -154,7 +160,7 @@ class MetaContextPlacerPhase(setting: Setting) extends CommonPhase:
                   Literal(Constant(tree.name.toString)),
                   tree.positionTree,
                   mkOptionString(clsSym.docString),
-                  mkList(clsSym.staticAnnotations.map(_.tree)),
+                  mkList(clsSym.staticAnnotations.map(a => dropProxies(a.tree))),
                   simpleArgsListMapTree
                 )
               )

--- a/plugin/src/main/scala/plugin/MetaContextPlacerPhase.scala
+++ b/plugin/src/main/scala/plugin/MetaContextPlacerPhase.scala
@@ -59,17 +59,13 @@ class MetaContextPlacerPhase(setting: Setting) extends CommonPhase:
   private def clsMetaArgsOverrideDef(owner: Symbol, clsMetaArgsTree: Tree)(using
       Context
   ): Tree =
-    val sym =
-      newSymbol(
-        owner,
-        "__clsMetaArgs".toTermName,
-        Override | Protected | Method | Touched,
-        clsMetaArgsTpe
-      )
-    DefDef(
-      sym,
-      clsMetaArgsTree
+    val sym = newSymbol(
+      owner,
+      "__clsMetaArgs".toTermName,
+      Override | Protected | Method | Touched,
+      clsMetaArgsTpe
     )
+    DefDef(sym, clsMetaArgsTree)
   end clsMetaArgsOverrideDef
 
   private def clsMetaArgsOverrideDef(owner: Symbol)(using Context): Tree =
@@ -103,11 +99,6 @@ class MetaContextPlacerPhase(setting: Setting) extends CommonPhase:
         val clsTpe = tree.tpe
         val clsSym = clsTpe.classSymbol.asClass
 
-        // debug(tree.show)
-        // if (clsSym.companionClass.hasAnnotation(topAnnotSym) && false)
-        //   val newTemplate = cpy.Template(template)(body = genMainDef(clsSym) :: template.body)
-        //   cpy.TypeDef(tree)(rhs = newTemplate)
-        // else
         if (clsTpe <:< hasClsMetaArgsTpe && !clsSym.isAnonymousClass)
           val paramBody = template.body.takeWhile {
             case x: TypeDef                 => true

--- a/plugin/src/main/scala/plugin/TopAnnotPhase.scala
+++ b/plugin/src/main/scala/plugin/TopAnnotPhase.scala
@@ -1,0 +1,161 @@
+package dfhdl.plugin
+
+import dotty.tools.dotc.*
+import plugins.*
+import core.*
+import Contexts.*
+import Symbols.*
+import Flags.*
+import SymDenotations.*
+import Decorators.*
+import ast.Trees.*
+import ast.{tpd, untpd, TreeTypeMap}
+import StdNames.nme
+import Names.{Designator, *}
+import Constants.Constant
+import Types.*
+
+import scala.language.implicitConversions
+import scala.compiletime.uninitialized
+import collection.mutable
+import annotation.tailrec
+import dotty.tools.dotc.ast.Trees.Alternative
+import dotty.tools.dotc.semanticdb.BooleanConstant
+
+/*
+  This phase creates a `top_<design_name>` object with a `DFApp` main entry point
+  for each design that has a `@top` annotation. The design parameters must have
+  default arguments and have the supported types. These arguments can then be
+  overridden by the command-line options that `DFApp` application provides.
+ */
+class TopAnnotPhase(setting: Setting) extends CommonPhase:
+  import tpd._
+
+  val phaseName = "TopAnnot"
+
+  override val runsAfter = Set("typer")
+  override val runsBefore = Set("MetaContextGen")
+  // override val debugFilter: String => Boolean = _.contains("Example.scala")
+  var topAnnotSym: ClassSymbol = uninitialized
+  var appTpe: TypeRef = uninitialized
+  var dfConstBoolTpe: TypeRef = uninitialized
+  var dfConstBitTpe: TypeRef = uninitialized
+  var dfConstInt32Tpe: TypeRef = uninitialized
+
+  override def transformStats(trees: List[Tree])(using Context): List[Tree] =
+    val retTrees = mutable.ListBuffer.empty[Tree]
+    var explored: List[Tree] = trees
+    while (explored.nonEmpty)
+      explored match
+        case (td @ TypeDef(tn, template: Template)) :: rest if td.tpe <:< hasDFCTpe =>
+          val clsSym = td.symbol.asClass
+          // has top annotation and no companion object
+          clsSym.getAnnotation(topAnnotSym).map(a => dropProxies(a.tree)) match
+            case Some(topAnnotTree @ Apply(Apply(_, topAnnotOptionsTrees), _)) =>
+              // genMain argument in top annotation is true by default
+              val genMain = topAnnotOptionsTrees match
+                case Literal(Constant(genMain: Boolean)) :: Nil => genMain
+                case _                                          => true
+              if (genMain)
+                // the top entry point module symbol
+                val dfApp = newCompleteModuleSymbol(
+                  ctx.owner,
+                  s"top_${tn}".toTermName,
+                  Touched,
+                  Touched | NoInits,
+                  List(defn.ObjectType, appTpe),
+                  Scopes.newScope
+                )
+                val moduleCls = dfApp.moduleClass.asClass
+                if (template.constr.paramss.length > 1)
+                  report.error(
+                    "Unsupported multiple parameter blocks for top-level design.",
+                    template.constr.srcPos
+                  )
+                val designNameTree = Literal(Constant(tn.toString))
+                val topScalaPathTree = Literal(Constant(dfApp.fullName.toString()))
+                val paramVDs =
+                  template.constr.paramss.flatten.collect { case vd: ValDef => vd }
+                val dsnArgNames = mkList(paramVDs.map(vd => Literal(Constant(vd.name.toString))))
+                extension (vd: Type)
+                  def argType: Option[String] =
+                    if (vd <:< defn.IntType) Some("Int")
+                    else if (vd <:< defn.StringType) Some("String")
+                    else if (vd <:< defn.DoubleType) Some("Double")
+                    else if (vd <:< defn.BooleanType) Some("Boolean")
+                    else if (vd <:< dfConstInt32Tpe) Some("DFHDL Int")
+                    else if (vd <:< dfConstBoolTpe) Some("DFHDL Boolean")
+                    else if (vd <:< dfConstBitTpe) Some("DFHDL Bit")
+                    else None
+
+                val dsnArgTypes = mkList(paramVDs.map { vd =>
+                  vd.tpt.tpe.argType match
+                    case Some(value) => Literal(Constant(value))
+                    case _ =>
+                      report.error("Unsupported top-level type", vd.srcPos)
+                      EmptyTree
+                })
+                val defaultMap = mutable.Map.empty[Int, Tree]
+                rest match
+                  case (_: ValDef) :: (compSym @ TypeDef(_, compTemplate: Template)) :: _
+                      if compSym.symbol.companionClass == clsSym =>
+                    compTemplate.body.foreach {
+                      case dd @ DefDef(NameKinds.DefaultGetterName(n, i), _, _, _) =>
+                        defaultMap += i -> ref(dd.symbol)
+                      case _ =>
+                    }
+                  case _ =>
+                val dsnArgValues =
+                  mkList(
+                    paramVDs.zipWithIndex.map((vd, i) =>
+                      defaultMap.get(i) match
+                        case Some(value) => value
+                        case None =>
+                          report.error(
+                            "Missing default value for top-level design argument.",
+                            vd.srcPos
+                          )
+                          EmptyTree
+                    )
+                  )
+                val dsnArgDescs =
+                  mkList(paramVDs.map(vd => Literal(Constant(vd.symbol.docString.getOrElse("")))))
+                val setInitials = This(moduleCls).select("setInitials".toTermName).appliedToArgs(
+                  List(
+                    designNameTree, topScalaPathTree, topAnnotTree, dsnArgNames, dsnArgTypes,
+                    dsnArgValues, dsnArgDescs
+                  )
+                )
+                val dsnInstArgs = paramVDs.map(vd =>
+                  This(moduleCls).select("getDsnArg".toTermName).appliedTo(
+                    Literal(Constant(vd.name.toString))
+                  )
+                )
+                val dsnInst = New(clsSym.typeRef, dsnInstArgs)
+                val setDsn = This(moduleCls).select("setDsn".toTermName).appliedTo(dsnInst)
+                retTrees ++= td :: ModuleDef(dfApp, List(setInitials, setDsn)).trees
+                explored = rest
+              else
+                retTrees += td
+                explored = rest
+              end if
+            case _ =>
+              retTrees += td
+              explored = rest
+          end match
+        case _ =>
+          retTrees += explored.head
+          explored = explored.drop(1)
+    end while
+    retTrees.toList
+  end transformStats
+
+  override def prepareForUnit(tree: Tree)(using Context): Context =
+    super.prepareForUnit(tree)
+    topAnnotSym = requiredClass("dfhdl.top")
+    appTpe = requiredClassRef("dfhdl.DFApp")
+    dfConstBoolTpe = requiredClassRef("dfhdl.core.DFConstBool")
+    dfConstBitTpe = requiredClassRef("dfhdl.core.DFConstBit")
+    dfConstInt32Tpe = requiredClassRef("dfhdl.core.DFConstInt32")
+    ctx
+end TopAnnotPhase

--- a/plugin/src/main/scala/plugin/TopAnnotPhase.scala
+++ b/plugin/src/main/scala/plugin/TopAnnotPhase.scala
@@ -92,7 +92,10 @@ class TopAnnotPhase(setting: Setting) extends CommonPhase:
                   vd.tpt.tpe.argType match
                     case Some(value) => Literal(Constant(value))
                     case _ =>
-                      report.error("Unsupported top-level type", vd.srcPos)
+                      report.error(
+                        "Unsupported argument's type for top-level design with a default app entry point.\nEither use a supported type or disable the app entry point generation with `@top(false)`.",
+                        vd.srcPos
+                      )
                       EmptyTree
                 })
                 val defaultMap = mutable.Map.empty[Int, Tree]
@@ -112,7 +115,7 @@ class TopAnnotPhase(setting: Setting) extends CommonPhase:
                         case Some(value) => value
                         case None =>
                           report.error(
-                            "Missing default value for top-level design argument.",
+                            "Missing argument's default value for top-level design with a default app entry point.\nEither add a default value or disable the app entry point generation with `@top(false)`.",
                             vd.srcPos
                           )
                           EmptyTree


### PR DESCRIPTION
This PR breaks backward source compatibility

# Add `options.ElaborationOptions` and move clock/reset configuration there
**Migration**: change `option.CompilerOptions.ClkCfg` to  `option.ElaborationOptions.ClkCfg`. Same for `RstCfg`.

# `@top` annotation
This annotation is now must be applied on top-level design declarations. 
E.g.: `@top class Example extends RTDesign`
Its purpose:
* Carry now newly created (implicit) elaboration options into the elaboration operation.
* Create a main entry point application named `top_<design_name>` that can get user command-line options. Currently the command-line only enables updating the top-level arguments and selecting mode of running. In the near future more options will be added.
* Use `@top(false)` to just add the annotation without creating a main entry point.

**Migration**: for top-level designs add `@top(false)` annotation if you don't want a main entry point.

# Support for vector lengths as embedded parameters
Same as already existed for `UInt`,`SInt`,`Bits` widths, now exists for a generic vector length. E.g.:
```scala
val depth: Int <> CONST = 10
val dataWidth: Int <> CONST = 16
val vec = Bits(dataWidth) X depth <> VAR
```

# Other minor updates:
* add missing checks for proper vector lengths.
* some internal refactorings