### PR TITLE
Fix plugin issue caused by the compiler casting a macro result

### DIFF
--- a/plugin/src/main/scala/plugin/CustomControlPhase.scala
+++ b/plugin/src/main/scala/plugin/CustomControlPhase.scala
@@ -621,7 +621,10 @@ class CustomControlPhase(setting: Setting) extends CommonPhase:
           rhs match
             case Apply(_, List(Apply(_, List(Typed(SeqLiteral(elems, _), _))))) =>
               Some(elems)
-            case _ => None
+            case TypeApply(sym @ Select(sel, _), _) if sym.symbol == defn.Any_isInstanceOf =>
+              unapply(sel)
+            case _ => 
+              None
     end SI
     object Struct:
       def unapply(arg: UnApply)(using Context): Option[(Type, List[Tree])] =


### PR DESCRIPTION
Found when trying to backport a PR to LTS: https://github.com/scala/scala3/pull/24002.
We are now more frequently casting the result of the macro, which didn't play well with the plugin here.
After this PR, the project should compile on the nightly versions of the compiler.